### PR TITLE
Update Libessentials with more software and WKHTMLTOPDF

### DIFF
--- a/dependencies/install_lib_essentials.sh
+++ b/dependencies/install_lib_essentials.sh
@@ -2,4 +2,4 @@
 
 apt-get update
 apt-get -y install build-essential curl git-core python-software-properties htop vim libfontconfig1 libgmp-dev software-properties-common
-apt-get -y install zlib1g-dev libssl-dev libreadline6-dev libyaml-dev libncurses5-dev libxml2-dev libxslt-dev libsqlite3-dev
+apt-get -y install zlib1g-dev libssl-dev libreadline6-dev libyaml-dev libncurses5-dev libxml2-dev libxslt-dev libsqlite3-dev unzip tree

--- a/dependencies/install_wkhtmltopdf_32bit_server.sh
+++ b/dependencies/install_wkhtmltopdf_32bit_server.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+apt-get update
+apt-get install xfonts-75dpi
+
+wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-i386.deb
+dpkg -i wkhtmltox-0.12.2_linux-trusty-i386.deb

--- a/dependencies/install_wkhtmtopdf_64bit_server.sh
+++ b/dependencies/install_wkhtmtopdf_64bit_server.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+apt-get update
+apt-get install openssl build-essential xorg libssl-dev xfonts-75dpi
+
+wget http://download.gna.org/wkhtmltopdf/0.12/0.12.2/wkhtmltox-0.12.2_linux-trusty-amd64.deb
+dpkg -i wkhtmltox-0.12.2_linux-trusty-amd64.deb


### PR DESCRIPTION
Added:

- unzip
- tree

to lib essentials and added installers for 64bit and 32bit versions of wkhtmltopdf library